### PR TITLE
refactor: avoid use of unnecessary pointer

### DIFF
--- a/src/domain/field.go
+++ b/src/domain/field.go
@@ -1,15 +1,15 @@
 package domain
 
 type Field struct {
-	Value [][]*FieldCell
+	Value [][]FieldCell
 }
 
 func NewField() *Field {
-	field := make([][]*FieldCell, 8)
+	field := make([][]FieldCell, 8)
 	for x := range field {
-		field[x] = make([]*FieldCell, 8)
+		field[x] = make([]FieldCell, 8)
 		for y := range field[x] {
-			field[x][y] = &FieldCell{
+			field[x][y] = FieldCell{
 				Stone: EmptyStone,
 				Pos:   FieldPos{x, y},
 			}
@@ -30,9 +30,9 @@ type FieldCell struct {
 }
 
 type PutableFieldCell struct {
-	*FieldCell
+	FieldCell
 	PutableStone    Stone
-	ReversibleCells []*FieldCell
+	ReversibleCells []FieldCell
 }
 
 type FieldPos struct {

--- a/src/ui/gui/field_view.go
+++ b/src/ui/gui/field_view.go
@@ -13,7 +13,7 @@ type FieldView struct {
 	*tview.Table
 	GuiView
 
-	highlightedCell *domain.FieldCell
+	highlightedCell domain.FieldCell
 }
 
 func newFieldView() *FieldView {
@@ -62,7 +62,7 @@ func (f *FieldView) update(g *Gui) {
 					newcell = tview.NewTableCell(EMPTY_STONE_UNICODE)
 				}
 
-				if hcell != nil && hcell.Pos.X == ridx && hcell.Pos.Y == cidx {
+				if hcell.Pos.X == ridx && hcell.Pos.Y == cidx {
 					newcell.SetBackgroundColor(tcell.ColorAqua)
 				}
 

--- a/src/ui/gui/gui.go
+++ b/src/ui/gui/gui.go
@@ -80,7 +80,7 @@ func (g *Gui) updateFieldView() {
 	go g.fieldView.update(g)
 }
 
-func (g *Gui) highlightFieldCell(cell *domain.FieldCell) {
+func (g *Gui) highlightFieldCell(cell domain.FieldCell) {
 	g.fieldView.highlightedCell = cell
 	g.updateFieldView()
 }


### PR DESCRIPTION
duel mode で enter 連打

連打している以上、実行時間は当てにならない。10000回ヒープへのアロケーションを削減しているので、気持ちパフォーマンス改善。
```
~/Documents/Github/reversi main*                                                                                                          00:54:26
❯ go test -mode=cli  -bench . -benchmem
goos: darwin
goarch: amd64
pkg: reversi
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
BenchmarkMain-8                1        4760088295 ns/op        43636424 B/op    2334128 allocs/op
PASS
ok      reversi 5.096s

~/Documents/Github/reversi feature/avoid_unncessary_pointer*                                                                          11s 01:00:52
❯ go test -mode=cli  -bench . -benchmem
goos: darwin
goarch: amd64
pkg: reversi
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
BenchmarkMain-8                1        5820365210 ns/op        47125360 B/op    2324984 allocs/op
PASS
ok      reversi 6.014s
```